### PR TITLE
Update library to use Handel's new style of env variables and param store prefix.

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -1,27 +1,22 @@
 const serviceList = exports.serviceList = {
-  dynamodb: { prefix: 'DYNAMODB', vars: [ 'TABLE_NAME', 'TABLE_ARN' ] },
-  efs: { prefix: 'EFS', vars: [ 'MOUNT_DIR' ] },
-  memcached: { prefix: 'MEMCACHED', vars: [ 'ADDRESS', 'PORT' ] },
-  mysql: { prefix: 'MYSQL', vars: [ 'ADDRESS', 'PORT', 'USERNAME', 'DATABASE_NAME' ] },
-  postgresql: { prefix: 'POSTGRESQL', vars: [ 'ADDRESS', 'PORT', 'USERNAME', 'DATABASE_NAME' ] },
-  redis: { prefix: 'REDIS', vars: [ 'ADDRESS', 'PORT' ] },
-  s3: { prefix: 'S3', vars: [ 'BUCKET_NAME', 'BUCKET_URL', 'REGION_ENDPOINT' ] },
-  sns: { prefix: 'SNS', vars: [ 'TOPIC_ARN', 'TOPIC_NAME' ] },
-  sqs: { prefix: 'SQS', vars: [ 'QUEUE_NAME', 'QUEUE_URL', 'QUEUE_ARN' ] }
+  dynamodb: { vars: [ 'TABLE_NAME', 'TABLE_ARN' ] },
+  efs: { vars: [ 'MOUNT_DIR' ] },
+  memcached: { vars: [ 'ADDRESS', 'PORT' ] },
+  mysql: { vars: [ 'ADDRESS', 'PORT', 'USERNAME', 'DATABASE_NAME' ] },
+  postgresql: { vars: [ 'ADDRESS', 'PORT', 'USERNAME', 'DATABASE_NAME' ] },
+  redis: { vars: [ 'ADDRESS', 'PORT' ] },
+  s3: { vars: [ 'BUCKET_NAME', 'BUCKET_URL', 'REGION_ENDPOINT' ] },
+  sns: { vars: [ 'TOPIC_ARN', 'TOPIC_NAME' ] },
+  sqs: { vars: [ 'QUEUE_NAME', 'QUEUE_URL', 'QUEUE_ARN' ] }
 }
 
 const handelEnv = () => ({
   appName: process.env.HANDEL_APP_NAME,
   envName: process.env.HANDEL_ENVIRONMENT_NAME,
   serviceName: process.env.HANDEL_SERVICE_NAME,
-  serviceVersion: process.env.HANDEL_SERVICE_VERSION
+  serviceVersion: process.env.HANDEL_SERVICE_VERSION,
+  parameterStorePrefix: process.env.HANDEL_PARAMETER_STORE_PREFIX
 })
-
-const partialPrefix = () => {
-  const {appName, envName} = handelEnv()
-  const transform = s => s.toUpperCase().replace(/-/g, '_')
-  return [transform(appName), transform(envName)].join('_')
-}
 
 const resolveService = serviceKey => {
   const service = Object.keys(serviceList).find(k => k === serviceKey)
@@ -30,10 +25,6 @@ const resolveService = serviceKey => {
   }
   throw new Error(`'${serviceKey}' is not a recognized handel service which exports environment variables!`)
 }
-
-const servicePrefix = serviceKey => resolveService(serviceKey).prefix
-
-const servicePartialPrefix = service => [servicePrefix(service), partialPrefix()].join('_')
 
 const resolveVariable = (serviceKey, variable) => {
   const service = resolveService(serviceKey)
@@ -51,11 +42,9 @@ const getVariable = (s, i, v) => {
   const service = s.toLowerCase()
   const variable = v.toUpperCase().replace(/-/g, '_')
   const itemName = i.toUpperCase().replace(/-/g, '_')
-  const key = [ servicePartialPrefix(service), itemName.toUpperCase(), resolveVariable(service, variable) ].join('_')
+  const key = [ itemName.toUpperCase(), resolveVariable(service, variable) ].join('_')
   return process.env[key]
 }
 
 exports.getVariable = getVariable
 exports.handelEnv = handelEnv
-exports.partialPrefix = partialPrefix
-exports.servicePartialPrefix = servicePartialPrefix

--- a/lib/parameterStore.js
+++ b/lib/parameterStore.js
@@ -4,7 +4,7 @@ const env = require('./env')
 
 const fetchParameters = (AWS, keyList) => {
   const handelEnv = env.handelEnv()
-  const prefix = [handelEnv.appName, handelEnv.envName].join('.')
+  const prefix = handelEnv.parameterStorePrefix
   const Names = keyList.map(k => [prefix, k].join('.'))
   const params = { WithDecryption: true, Names }
   const ssm = new AWS.SSM({apiVersion: '2014-11-06'})

--- a/test/testEnvironment.js
+++ b/test/testEnvironment.js
@@ -6,43 +6,32 @@ const testVars = {
   HANDEL_ENVIRONMENT_NAME: 'dev',
   HANDEL_SERVICE_NAME: 'TestArtifact',
   HANDEL_SERVICE_VERSION: 'v1',
-  DYNAMODB_TEST_APP_DEV_MY_TABLE_TABLE_NAME: 'mytable',
-  DYNAMODB_TEST_APP_DEV_MY_TABLE_TABLE_ARN: 'arn:faketestvaluefortable',
-  EFS_TEST_APP_DEV_MYEFS_MOUNT_DIR: '/fake/mountdir',
-  MEMCACHED_TEST_APP_DEV_MYELASTICACHE_ADDRESS: 'my_cache.fake.com',
-  MEMCACHED_TEST_APP_DEV_MYELASTICACHE_PORT: '9999',
-  MYSQL_TEST_APP_DEV_MYDB_ADDRESS: 'my_db.fake.com',
-  MYSQL_TEST_APP_DEV_MYDB_PORT: '8888',
-  MYSQL_TEST_APP_DEV_MYDB_USERNAME: 'fakeuser',
-  MYSQL_TEST_APP_DEV_MYDB_DATABASE_NAME: 'fakedb',
-  POSTGRESQL_TEST_APP_DEV_MYDB_ADDRESS: 'my_db2.fake.com',
-  POSTGRESQL_TEST_APP_DEV_MYDB_PORT: '8989',
-  POSTGRESQL_TEST_APP_DEV_MYDB_USERNAME: 'fakeuser2',
-  POSTGRESQL_TEST_APP_DEV_MYDB_DATABASE_NAME: 'fakedb2',
-  REDIS_TEST_APP_DEV_MYCACHE_ADDRESS: 'my_cache2.fake.com',
-  REDIS_TEST_APP_DEV_MYCACHE_PORT: '9898',
-  S3_TEST_APP_DEV_MYBUCKET_BUCKET_NAME: 'my_bucket',
-  S3_TEST_APP_DEV_MYBUCKET_BUCKET_URL: 'my_bucket.fake.com',
-  S3_TEST_APP_DEV_MYBUCKET_REGION_ENDPOINT: 'us-west-2',
-  SNS_TEST_APP_DEV_MYTOPIC_TOPIC_ARN: 'arn:faketestvaluefortopic',
-  SNS_TEST_APP_DEV_MYTOPIC_TOPIC_NAME: 'testtopic',
-  SQS_TEST_APP_DEV_MYQUEUE_QUEUE_NAME: 'myqueue',
-  SQS_TEST_APP_DEV_MYQUEUE_QUEUE_URL: 'my_queue.fake.com',
-  SQS_TEST_APP_DEV_MYQUEUE_QUEUE_ARN: 'arn:faketestvalueforqueue'
+  HANDEL_PARAMETER_STORE_PREFIX: 'test-app.dev',
+  MY_TABLE_TABLE_NAME: 'mytable',
+  MY_TABLE_TABLE_ARN: 'arn:faketestvaluefortable',
+  MYEFS_MOUNT_DIR: '/fake/mountdir',
+  MYELASTICACHE_ADDRESS: 'my_cache.fake.com',
+  MYELASTICACHE_PORT: '9999',
+  MYDB_ADDRESS: 'my_db.fake.com',
+  MYDB_PORT: '8888',
+  MYDB_USERNAME: 'fakeuser',
+  MYDB_DATABASE_NAME: 'fakedb',
+  MYDB2_ADDRESS: 'my_db2.fake.com',
+  MYDB2_PORT: '8989',
+  MYDB2_USERNAME: 'fakeuser2',
+  MYDB2_DATABASE_NAME: 'fakedb2',
+  MYCACHE_ADDRESS: 'my_cache2.fake.com',
+  MYCACHE_PORT: '9898',
+  MYBUCKET_BUCKET_NAME: 'my_bucket',
+  MYBUCKET_BUCKET_URL: 'my_bucket.fake.com',
+  MYBUCKET_REGION_ENDPOINT: 'us-west-2',
+  MYTOPIC_TOPIC_ARN: 'arn:faketestvaluefortopic',
+  MYTOPIC_TOPIC_NAME: 'testtopic',
+  MYQUEUE_QUEUE_NAME: 'myqueue',
+  MYQUEUE_QUEUE_URL: 'my_queue.fake.com',
+  MYQUEUE_QUEUE_ARN: 'arn:faketestvalueforqueue'
 }
 process.env = Object.assign({}, process.env, testVars)
-
-const serviceList = [
-  'dynamodb',
-  'efs',
-  'memcached',
-  'mysql',
-  'postgresql',
-  'redis',
-  's3',
-  'sns',
-  'sqs'
-]
 
 test('Handel Environment', assert => {
   const actual = util.handelEnv()
@@ -50,26 +39,11 @@ test('Handel Environment', assert => {
     appName: 'test-app',
     envName: 'dev',
     serviceName: 'TestArtifact',
-    serviceVersion: 'v1'
+    serviceVersion: 'v1',
+    parameterStorePrefix: 'test-app.dev'
   }
   assert.deepEqual(actual, expected, 'Correctly loaded handel common variables')
   assert.end()
-})
-
-test('Partial Environment Prefix', assert => {
-  const actual = util.partialPrefix()
-  const expected = 'TEST_APP_DEV'
-  assert.equal(actual, expected, 'Correctly generated a partial environmental prefix')
-  assert.end()
-})
-
-test('Each service prefix', assert => {
-  assert.plan(serviceList.length)
-  serviceList.forEach(service => {
-    const actual = util.servicePartialPrefix(service)
-    const expected = `${service.toUpperCase()}_TEST_APP_DEV`
-    assert.equal(actual, expected, `${service} service prefix generated correctly`)
-  })
 })
 
 test('Service variable', assert => {


### PR DESCRIPTION
Now that we aren't going to support external references anymore, we
don't need to inject service type, app name, and env name in the env
variable prefix anymore. The new prefix is <SERVICE_NAME>_<VAR_NAME>,
which is much shorter and easier to construct. I've updated handel-utils
to use this new style.

Also, Handel now injects a value called "HANDEL_PARAMETER_STORE_PREFIX",
which contains the fully constructed parameter store prefix value, so
I updated this library to use that too.

All the tests seem to be passing for me locally on my machine.